### PR TITLE
POK-38942: fix so other user's files are not deleted in shared envs

### DIFF
--- a/bin/hhvm-restart-wrapper
+++ b/bin/hhvm-restart-wrapper
@@ -306,7 +306,7 @@ class Zynga_HHVM_Service extends Zynga_Base {
         $tmp_hh_dir . ' -user ' . $USER . ' -type f -exec rm {} \; 2> /dev/null '
       );
       $this->_findCommand->run(
-        $tmp_hh_dir . ' -user ' . $USER . ' -type d -exec rm -r {} \; 2> /dev/null '
+        $tmp_hh_dir . ' -user ' . $USER . ' -type d -exec rmdir {} \; 2> /dev/null '
       );
       $this->_findCommand->run(
         $tmp_hh_dir . ' -user ' . $USER . ' -type l -exec unlink {} \; 2> /dev/null '


### PR DESCRIPTION
Since /tmp/hh_server will be owned by one dev on a shared box, I think the current deletion process can try to delete files which are not owned by the executing user. -user applies to the top level dir in find, but -r in rm does not apply the -user restriction 